### PR TITLE
bl-exit: add configuration via config for LOCK_SCREEN_COMMAND

### DIFF
--- a/bin/bl-exit
+++ b/bin/bl-exit
@@ -68,6 +68,9 @@ It can be done with the vlock package installed, using the
 command 'vlock'. This script does not handle that case.
 If you have a graphical environment running the probable cause
 of seeing this message is that no display manager is installed.
+An alternative screen locker can be set in
+$HOME/.config/bunsen/bl-lock with the following line:
+LOCK_SCREEN_COMMAND=\"what-locks-screen --options\"
 "
 
 # Some screen locking software does not listen for logind calls,
@@ -100,6 +103,10 @@ LOCK_SCREEN_COMMAND=""
 #                                                                      #
 ########################################################################
 logoutctl(){
+    # because this file can be 'touched' we must check for existence and
+    # that it contains data
+    [[ -f "$HOME/.config/bunsen/bl-lock" ]] && [[ -s "$HOME/.config/bunsen/bl-lock" ]] && \
+        source $HOME/.config/bunsen/bl-lock
     if [[ ! -z $YAD_PID ]]; then
         kill -SIGUSR1 $YAD_PID
     fi
@@ -180,7 +187,8 @@ tty_menu(){
 
 # can only use this in a graphical session
 yad_gui() {
-    yad --class=WmanExit --title "Exit" --close-on-unfocus --undecorated --center --on-top --borders=10 --window-icon=system-log-out \
+    yad --class=WmanExit --title "Exit" --close-on-unfocus --undecorated --center \
+        --on-top --borders=10 --window-icon=system-log-out --name=system-log-out \
         --button=" _Logout!system-log-out!Logout":'bash -c "logoutctl terminate-session"' \
         --button=" L_ock Screen!system-lock-screen!":'bash -c "logoutctl lock-session"' \
         --button=" _Suspend!system-suspend!":'bash -c "logoutctl suspend"' \

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+bunsen-exit (13.0-1) carbon; urgency=medium
+
+  * Reinstate config file.
+
+ -- Mick Amadio <01micko@gmail.com>  Wed 24 Apr 2024 19:51:39 +1000
+
 bunsen-exit (12.1-1) boron; urgency=medium
 
   * Add .desktop file for auto-generated menus.


### PR DESCRIPTION
Specifically, I needed this for labwc which use 'swaylock'

I need this:

```
swaylock -F -f --indicator-idle-visible  -i $HOME/Pictures/wallpapers/bunsen/default/default
```

Feel free to edit as necessary.