### PR TITLE
bin/bl-exit: add yad arg --name so labwc can use a windowRule

### DIFF
--- a/bin/bl-exit
+++ b/bin/bl-exit
@@ -263,7 +263,7 @@ yad_gui() {
             buttons+=("${yadbutton[$b]}") ;;
         esac
     done
-    yad --class=WmanExit --title "Exit" --close-on-unfocus --undecorated --center --on-top --borders=10 --window-icon=system-log-out \
+    yad --class=WmanExit --title "Exit" --close-on-unfocus --undecorated --center --on-top --borders=10 --window-icon=system-log-out --name=system-log-out \
     "${buttons[@]}"
 }
 


### PR DESCRIPTION
Yad exposes an `app_id` for wayland when the `--name` arg is used. 